### PR TITLE
Fix ROOT file .Close() check

### DIFF
--- a/alian/sandbox/root_output.py
+++ b/alian/sandbox/root_output.py
@@ -24,7 +24,7 @@ class SingleRootFile(object):
 
     def __del__(self):
         if SingleRootFile.__instance:
-            if SingleRootFile.__instance.root_file:
+            if SingleRootFile.__instance.root_file.IsOpen():
                 log.info(f'closing {SingleRootFile.__instance.root_file.GetName()}')
                 SingleRootFile.__instance.close()
         


### PR DESCRIPTION
If the file is closed manually with `SingleRootFile.close()` (e.g. in `alian/sandbox/jet_axis/pythia_jet_axis.py`), then it will try to close the file again when the `SingleRootFile` object goes out of scope, causing a segfault when trying to write all `objects`. Not sure if this is due to a change in behavior of the truthiness of a `TFile` instance, but `IsOpen()` has been implemented since 2000, so this fix should be transparent (and still allows for file closing as part of going out of scope as intended)